### PR TITLE
Configure `bazel-lockfile-merge`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# A custom merge driver for the Bazel lockfile.
+# https://bazel.build/external/lockfile#automatic-resolution
+MODULE.bazel.lock merge=bazel-lockfile-merge


### PR DESCRIPTION
Followed the steps from https://bazel.build/external/lockfile#automatic-resolution to reduce the likelihood of `MODULE.bazel.lock` merge conflicts.